### PR TITLE
Disable LTO when building WineASIO

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,6 +10,7 @@ url='https://github.com/wineasio/wineasio'
 arch=('i686' 'x86_64' 'x86_64_v3')
 license=('LGPL')
 
+options=('!lto')
 depends=('wine' 'jack')
 makedepends=('git')
 depends_x86_64+=('lib32-jack')


### PR DESCRIPTION
According to https://github.com/wineasio/wineasio/issues/48 LTO needs to be disabled when building WineASIO. This alters PKGBUILD to explicitly disable it when building the package. 