### PR TITLE
update for 1.2.0

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -36,7 +36,7 @@ pkgver() {
 
 prepare() {
   cd "${_basename}"
-  
+
   _submodules=(
     'rtaudio'
   )
@@ -45,21 +45,21 @@ prepare() {
     git submodule set-url ${submodule} "${srcdir}/${submodule##*/}"
     git -c protocol.file.allow=always submodule update ${submodule}
   done
-  
+
   # Adjust PREFIX value in script files
   sed -i "s?X-PREFIX-X?\/usr?" gui/wineasio-settings
 }
 
 build() {
   cd "${_basename}"
-  
+
   if [[ "$CARCH" == 'x86_64' ]] || [[ "$CARCH" == 'x86_64_v3' ]]; then
     make 64
     pushd build64
     winebuild -m64 --dll --fake-module -E ../wineasio.dll.spec asio.c.o main.c.o regsvr.c.o > wineasio.dll
     popd
   fi
-  
+
   make 32
   cd build32
   winebuild -m32 --dll --fake-module -E ../wineasio.dll.spec asio.c.o main.c.o regsvr.c.o > wineasio.dll
@@ -75,11 +75,11 @@ package() {
   install -dm755 "$pkgdir"/usr/lib32/wine/i386-{windows,unix}
   install -m644 build32/wineasio32.dll "$pkgdir"/usr/lib32/wine/i386-windows/
   install -m644 build32/wineasio32.dll.so "$pkgdir"/usr/lib32/wine/i386-unix/
-  
+
   install -D -m644 gui/settings.py "$pkgdir"/usr/share/"$_basename"/settings.py
   install -D -m644 gui/ui_settings.py "$pkgdir"/usr/share/"$_basename"/ui_settings.py
   install -D -m644 README.md "$pkgdir"/usr/share/"$_basename"/README.md
-  
+
   install -D -m755 wineasio-register "$pkgdir"/usr/bin/wineasio-register
   install -D -m755 gui/wineasio-settings "$pkgdir"/usr/bin/wineasio-settings
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 _basename=wineasio
 pkgname="${_basename}-git"
-pkgver=1.1.0.r0.g56c3e9d
+pkgver=1.2.0.r8.g6529641
 pkgrel=1
 
 pkgdesc='ASIO driver implementation for Wine'
@@ -10,23 +10,23 @@ url='https://github.com/wineasio/wineasio'
 arch=('i686' 'x86_64' 'x86_64_v3')
 license=('LGPL')
 
-options=('!lto')
-depends=('wine' 'jack')
+options=('!lto' '!debug')
+depends=('wine' 'jack' 'realtime-privileges' 'python-pyqt5')
 makedepends=('git')
 depends_x86_64+=('lib32-jack')
 makedepends_x86_64=('gcc-multilib')
 provides=('wineasio')
 conflicts=('wineasio')
 
+install="${_basename}".install
+
 source=(
   'wineasio'::'git+https://github.com/wineasio/wineasio.git'
   'rtaudio'::'git+https://github.com/falkTX/rtaudio.git'
-  'setup_wineasio.sh'
 )
 sha256sums=(
   'SKIP'
   'SKIP'
-  '6ab4819215d9cb2fe5133380ab629538fa5de7ddb0bea82f1b4cef7904cb856d'
 )
 
 pkgver() {
@@ -36,7 +36,7 @@ pkgver() {
 
 prepare() {
   cd "${_basename}"
-
+  
   _submodules=(
     'rtaudio'
   )
@@ -45,18 +45,21 @@ prepare() {
     git submodule set-url ${submodule} "${srcdir}/${submodule##*/}"
     git -c protocol.file.allow=always submodule update ${submodule}
   done
+  
+  # Adjust PREFIX value in script files
+  sed -i "s?X-PREFIX-X?\/usr?" gui/wineasio-settings
 }
 
 build() {
   cd "${_basename}"
-
+  
   if [[ "$CARCH" == 'x86_64' ]] || [[ "$CARCH" == 'x86_64_v3' ]]; then
     make 64
     pushd build64
     winebuild -m64 --dll --fake-module -E ../wineasio.dll.spec asio.c.o main.c.o regsvr.c.o > wineasio.dll
     popd
   fi
-
+  
   make 32
   cd build32
   winebuild -m32 --dll --fake-module -E ../wineasio.dll.spec asio.c.o main.c.o regsvr.c.o > wineasio.dll
@@ -72,7 +75,11 @@ package() {
   install -dm755 "$pkgdir"/usr/lib32/wine/i386-{windows,unix}
   install -m644 build32/wineasio32.dll "$pkgdir"/usr/lib32/wine/i386-windows/
   install -m644 build32/wineasio32.dll.so "$pkgdir"/usr/lib32/wine/i386-unix/
-
-  cd "$srcdir"
-  install -D -m755 setup_wineasio.sh "$pkgdir"/usr/bin/setup_wineasio
+  
+  install -D -m644 gui/settings.py "$pkgdir"/usr/share/"$_basename"/settings.py
+  install -D -m644 gui/ui_settings.py "$pkgdir"/usr/share/"$_basename"/ui_settings.py
+  install -D -m644 README.md "$pkgdir"/usr/share/"$_basename"/README.md
+  
+  install -D -m755 wineasio-register "$pkgdir"/usr/bin/wineasio-register
+  install -D -m755 gui/wineasio-settings "$pkgdir"/usr/bin/wineasio-settings
 }

--- a/setup_wineasio.sh
+++ b/setup_wineasio.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-WINE="${WINE:-$(which wine)}"
-
-"$WINE" regsvr32 wineasio.dll
-"${WINE}64" regsvr32 wineasio.dll || true

--- a/wineasio.install
+++ b/wineasio.install
@@ -1,0 +1,4 @@
+post_install() {
+  echo "Your user must belong to the realtime group in order to use wineasio."
+  echo "This can be done with 'sudo usermod -aG realtime \$(whoami)'"
+}


### PR DESCRIPTION
- removed setup script, setup and ship new upstream scripts instead (requires pyqt5)
- added realtime-privileges dependency + post install info
- added !debug option, for optimization